### PR TITLE
Expose 'security' for SSL pinning

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -49,6 +49,12 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   fileprivate var sequenceNumber = 0
   fileprivate var reconnected = false
 
+  public var security: SSLTrustValidator? {
+    didSet {
+      websocket.security = security
+    }
+  }
+
   public init(request: URLRequest, sendOperationIdentifiers: Bool = false, reconnectionInterval: TimeInterval = 0.5, connectingPayload: GraphQLMap? = [:]) {
     self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers


### PR DESCRIPTION
[BET-16](https://jira.thescore.com/browse/BET-16)

Exposes `security` property on the WebSocketTransport class in order to enable SSL pinning.