### PR TITLE
Add exception for assertFailure if the tests are running

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -261,6 +261,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
         /// Some tests were crashing on CI due to this assertion and found that this is a useful workaround.
+        /// Jira ticket: BET-10678
         /// Related post looking for help on the matter from Apollo's forum:
         /// https://community.apollographql.com/t/ios-unit-testing-with-urlsessionclient/3939
         if NSClassFromString("XCTest") == nil {

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -261,6 +261,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
         if NSClassFromString("XCTest") == nil {
+          print("Alex - XCTest == nil")
           assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         }
         return

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -70,6 +70,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
   public func invalidate() {
+    print("Alex - invalidate")
     self.hasBeenInvalidated.mutate { $0 = true }
     func cleanup() {
       self.session = nil
@@ -90,6 +91,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameter identifier: The identifier of the task to clear.
   open func clear(task identifier: Int) {
+    print("Alex - clear")
     self.tasks.mutate { _ = $0.removeValue(forKey: identifier) }
   }
   
@@ -121,7 +123,9 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       completion(.failure(URLSessionClientError.sessionInvalidated))
       return URLSessionTask()
     }
-    
+
+    print("Alex - sendRequest")
+
     let task = self.session.dataTask(with: request)
     let taskData = TaskData(rawCompletion: rawTaskCompletionHandler,
                             completionBlock: completion)
@@ -139,6 +143,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameter task: The task you wish to cancel.
   open func cancel(task: URLSessionTask) {
+    print("Alex - cancel")
     self.clear(task: task.taskIdentifier)
     task.cancel()
   }
@@ -197,7 +202,9 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       // No completion blocks, the task has likely been cancelled. Bail out.
       return
     }
-    
+
+    print("Alex - urlSession(task:didCompleteWithError:)")
+
     let data = taskData.data
     let response = taskData.response
     
@@ -260,6 +267,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
+        print("Alex - urlSession(dataTask:didReceive:) dataTask not found assertion")
         assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         return
       }

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -70,7 +70,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
   public func invalidate() {
-    print("Alex - invalidate")
     self.hasBeenInvalidated.mutate { $0 = true }
     func cleanup() {
       self.session = nil
@@ -91,7 +90,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameter identifier: The identifier of the task to clear.
   open func clear(task identifier: Int) {
-    print("Alex - clear")
     self.tasks.mutate { _ = $0.removeValue(forKey: identifier) }
   }
   
@@ -124,8 +122,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       return URLSessionTask()
     }
 
-    print("Alex - sendRequest")
-
     let task = self.session.dataTask(with: request)
     let taskData = TaskData(rawCompletion: rawTaskCompletionHandler,
                             completionBlock: completion)
@@ -143,7 +139,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameter task: The task you wish to cancel.
   open func cancel(task: URLSessionTask) {
-    print("Alex - cancel")
     self.clear(task: task.taskIdentifier)
     task.cancel()
   }
@@ -202,8 +197,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       // No completion blocks, the task has likely been cancelled. Bail out.
       return
     }
-
-    print("Alex - urlSession(task:didCompleteWithError:)")
 
     let data = taskData.data
     let response = taskData.response
@@ -267,8 +260,9 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
-        print("Alex - urlSession(dataTask:didReceive:) dataTask not found assertion")
-        assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
+        if NSClassFromString("XCTest") == nil {
+          assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
+        }
         return
       }
       

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -264,6 +264,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
           print("Alex - XCTest == nil")
           assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         }
+        print("Alex - outside")
         return
       }
       

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -258,11 +258,11 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       return
     }
 
-    if NSClassFromString("XCTest") != nil {
-        print("Alex - This is an XCTest")
-    }
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
+        /// Some tests were crashing on CI due to this assertion and found that this is a useful workaround.
+        /// Related post looking for help on the matter from Apollo's forum:
+        /// https://community.apollographql.com/t/ios-unit-testing-with-urlsessionclient/3939
         if NSClassFromString("XCTest") == nil {
           assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         }

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -260,16 +260,16 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
-        if NSClassFromString("XCTest") == nil {
-          print("Alex - XCTest == nil")
-          assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
-        }
-        if ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil {
-          print("Alex - inside other")
-        }
-        print("Alex - outside")
         return
       }
+      if NSClassFromString("XCTest") == nil {
+        print("Alex - XCTest == nil")
+        assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
+      }
+      if ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil {
+        print("Alex - inside other")
+      }
+      print("Alex - outside")
       
       taskData.append(additionalData: data)
     }

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -264,6 +264,9 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
           print("Alex - XCTest == nil")
           assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         }
+        if ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil {
+          print("Alex - inside other")
+        }
         print("Alex - outside")
         return
       }

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -257,19 +257,17 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
       // Task is in the process of cancelling, don't bother handling its data.
       return
     }
-    
+
+    if NSClassFromString("XCTest") != nil {
+        print("Alex - This is an XCTest")
+    }
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
+        if NSClassFromString("XCTest") == nil {
+          assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
+        }
         return
       }
-      if NSClassFromString("XCTest") == nil {
-        print("Alex - XCTest == nil")
-        assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
-      }
-      if ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil {
-        print("Alex - inside other")
-      }
-      print("Alex - outside")
       
       taskData.append(additionalData: data)
     }


### PR DESCRIPTION
We've been seeing tests crash with MockGraphQLDataClient. This _should_ prevent the tests from crashing.

This will be tested via CI on Sportsbook-iOS.