### PR TITLE
Add only Core subspec in test support

### DIFF
--- a/ApolloTestSupport.podspec
+++ b/ApolloTestSupport.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.visionos.deployment_target = '1.0'
 
   s.source_files = 'Sources/ApolloTestSupport/*.swift'
-  s.dependency 'Apollo', '= ' + version
+  s.dependency 'Apollo/Core', '= ' + version
 
 end


### PR DESCRIPTION
Without using `Apollo/Core` apparently cocoapods messes up and isn't able to create a single `Apollo` framework. It fails trying to create device builds 